### PR TITLE
Specific app VPC deployment

### DIFF
--- a/infra/app/.terraform.lock.hcl
+++ b/infra/app/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.60.0"
+  constraints = ">= 5.30.0, ~> 5.60"
+  hashes = [
+    "h1:Ou/WgUdyL4dSzfO1U5J0Z7i4FS4QRBVxqVWFFnRl0Fk=",
+    "zh:08f49c9eb865e136a55dda3eb2b790f6d55cdac49f6638391dbea4b865cf307b",
+    "zh:090dd8b40ebf0f8e9ea05b9a142add9caeb7988d3d96c5c112e8c67c0edf566f",
+    "zh:30f336af1b4f0824fce2cc6e81af0986b325b135436c9d892d081e435aeed67e",
+    "zh:338195ca3b41249874110253412d8913f770c22294af05799ea1e343050906f5",
+    "zh:3a8a45b17750b01192a0fbeeed0d05c2c04840344d78d5e3233b3ecbeec17a1c",
+    "zh:486efe72d39f0736d9b7e00e5b889288264458a57aa0cff2d75688d6db372ee5",
+    "zh:5fdccc448a085fea8ecfae43ae326840abfcdf1a0aa8b8c79dd466392aa5cc3a",
+    "zh:9521639755cd07ec7efde86a534770e436e16a93692d070a00f6419c1038d59c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c2fb9240a069da9f51e7379e76c3dfaad15a97430c2e32708a7d18345434e310",
+    "zh:daba836b89537dfa72bb8c77e88850c20fda2a3d0f5b3803cd3d6da0ce283e3e",
+    "zh:db7e0755ed120ed8311f6663f49aa7157da5072b906727db3a6c47d64e0b82c6",
+    "zh:ea5e3fca5197639c4ad1415ca96de2924a351ecd1a885dd9184843d5eec18dbb",
+    "zh:f3f322951d311e45a47361f24790a90a0b8ba6d3829a00c4066a361960d2ecef",
+    "zh:f48b44f4887d4b51a1406057f15f1e2161cb02b271b2659349958904c678e91c",
+  ]
+}

--- a/infra/app/aws_vpc.tf
+++ b/infra/app/aws_vpc.tf
@@ -1,0 +1,18 @@
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = local.vpc_name
+  cidr = local.vpc_cidr
+
+  azs             = local.vpc_azs
+  private_subnets = local.private_subnets
+  public_subnets  = local.public_subnets
+
+  private_subnet_names = [for index, subnet in local.private_subnets : "marmita-private-subnet-${index}"]
+  public_subnet_names = [for index, subnet in local.public_subnets : "marmita-public-subnet-${index}"]
+
+  single_nat_gateway = true
+  enable_nat_gateway = true
+  enable_vpn_gateway = false
+
+}

--- a/infra/app/data.tf
+++ b/infra/app/data.tf
@@ -1,0 +1,3 @@
+data "aws_availability_zones" "all_azs" {
+    state = "available"
+}

--- a/infra/app/env.tf
+++ b/infra/app/env.tf
@@ -1,0 +1,3 @@
+module "env" {
+    source = "../module/aws"
+}

--- a/infra/app/locals.tf
+++ b/infra/app/locals.tf
@@ -1,0 +1,9 @@
+locals {
+    vpc_cidr = "10.0.0.0/16"
+    vpc_name = "marmita-vpc"
+    num_azs = 2
+    vpc_azs = slice(data.aws_availability_zones.all_azs.names, 0, local.num_azs)
+
+    private_subnets = [for index, az in local.vpc_azs : cidrsubnet(local.vpc_cidr, 8, index)]
+    public_subnets = [for index, az in local.vpc_azs : cidrsubnet(local.vpc_cidr, 8, index + local.num_azs)]
+}

--- a/infra/app/provider.tf
+++ b/infra/app/provider.tf
@@ -1,0 +1,33 @@
+terraform {
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+            version = "~> 5.60"
+        }
+    }
+    backend "s3" {
+        bucket = "terraform-remote-state20240730194456941500000001"
+        kms_key_id = "cee1ea76-5ff9-452f-9aa9-83f807e40c77"
+        key = "infra/app/terraform.tfstate"
+        region = "us-east-1"
+        profile = "marmita-admin"
+        dynamodb_table = "marmita_app_remote_state"
+        encrypt = true
+    }
+
+    required_version = ">= 1.9.3"
+}
+
+provider "aws" {
+    profile = module.env.aws_provider.profile
+    region = module.env.aws_provider.region
+
+    default_tags {
+        tags = {
+            App = "marmita"
+            ManagedBy = "Terraform"
+            SourceCode = "infra/app/provider.tf"
+        }
+    }
+}
+

--- a/infra/remote_state/provider.tf
+++ b/infra/remote_state/provider.tf
@@ -21,5 +21,12 @@ terraform {
 provider "aws" {
     profile = module.env.aws_provider.profile
     region = module.env.aws_provider.region
+    default_tags {
+        tags = {
+            App = "marmita"
+            ManagedBy = "Terraform"
+            SourceCode = "infra/remote_state/provider.tf"
+        }
+    }
 }
 


### PR DESCRIPTION
## Context
This PR brings a new implementation of the VPC module inside the marmita app project.

## Changes
In terms of major, tangible changes, this PR implements:
- Default tags for original remote state directory;
- New directory that is responsible for holding the app infrastructure;
- Implementation of the VPC module for major foundational infrastructure creation.
