### PR TITLE
Moved previous webserver from a private subnet to a public one

### DIFF
--- a/infra/app/aws_ec2.tf
+++ b/infra/app/aws_ec2.tf
@@ -1,6 +1,6 @@
 resource "aws_instance" "marmita_backend_webserver" {
   ami                         = "ami-0ae8f15ae66fe8cda"
-  associate_public_ip_address = false
+  associate_public_ip_address = true
 
   iam_instance_profile = aws_iam_instance_profile.ssm_managed_ec2_instance_profile_core.name
   instance_type        = "t2.micro"

--- a/infra/app/aws_ec2.tf
+++ b/infra/app/aws_ec2.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "marmita_backend_webserver" {
   instance_type        = "t2.micro"
   security_groups      = [aws_security_group.webserver_backend_sg.id]
   source_dest_check    = false
-  subnet_id            = module.vpc.private_subnets[0]
+  subnet_id            = local.webserver_subnet
   tenancy              = "default"
 
   tags = {

--- a/infra/app/aws_sg.tf
+++ b/infra/app/aws_sg.tf
@@ -4,6 +4,8 @@ resource "aws_security_group" "webserver_backend_sg" {
   vpc_id      = module.vpc.vpc_id
 }
 
+# This is the only security group rule that should remain after a refactoring, leading the instance to
+# a private subnet.
 resource "aws_vpc_security_group_egress_rule" "webserver_backend_allow_ssm_vpce" {
   security_group_id            = aws_security_group.webserver_backend_sg.id
   referenced_security_group_id = aws_security_group.ssm_vpce_sg.id
@@ -14,18 +16,36 @@ resource "aws_vpc_security_group_egress_rule" "webserver_backend_allow_ssm_vpce"
 }
 
 resource "aws_vpc_security_group_egress_rule" "webserver_backend_allow_temp_internet_http_access" {
-  security_group_id            = aws_security_group.webserver_backend_sg.id
+  security_group_id = aws_security_group.webserver_backend_sg.id
 
-  cidr_ipv4 = "0.0.0.0/0"
+  cidr_ipv4   = "0.0.0.0/0"
   from_port   = "80"
   to_port     = "80"
   ip_protocol = "tcp"
 }
 
 resource "aws_vpc_security_group_egress_rule" "webserver_backend_allow_temp_internet_https_access" {
-  security_group_id            = aws_security_group.webserver_backend_sg.id
+  security_group_id = aws_security_group.webserver_backend_sg.id
 
-  cidr_ipv4 = "0.0.0.0/0"
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = "443"
+  to_port     = "443"
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "webserver_backend_allow_temp_internet_http_access" {
+  security_group_id = aws_security_group.webserver_backend_sg.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = "80"
+  to_port     = "80"
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "webserver_backend_allow_temp_internet_https_access" {
+  security_group_id = aws_security_group.webserver_backend_sg.id
+
+  cidr_ipv4   = "0.0.0.0/0"
   from_port   = "443"
   to_port     = "443"
   ip_protocol = "tcp"

--- a/infra/app/aws_sg.tf
+++ b/infra/app/aws_sg.tf
@@ -13,6 +13,24 @@ resource "aws_vpc_security_group_egress_rule" "webserver_backend_allow_ssm_vpce"
   ip_protocol = "tcp"
 }
 
+resource "aws_vpc_security_group_egress_rule" "webserver_backend_allow_temp_internet_http_access" {
+  security_group_id            = aws_security_group.webserver_backend_sg.id
+
+  cidr_ipv4 = "0.0.0.0/0"
+  from_port   = "80"
+  to_port     = "80"
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "webserver_backend_allow_temp_internet_https_access" {
+  security_group_id            = aws_security_group.webserver_backend_sg.id
+
+  cidr_ipv4 = "0.0.0.0/0"
+  from_port   = "443"
+  to_port     = "443"
+  ip_protocol = "tcp"
+}
+
 resource "aws_security_group" "ssm_vpce_sg" {
   name        = "ssm-vpce-sg"
   description = "Security group to be used with vpce related to the ssm service to log into the webserver"

--- a/infra/app/aws_vpce.tf
+++ b/infra/app/aws_vpce.tf
@@ -6,7 +6,7 @@ resource "aws_vpc_endpoint" "ssm_vpce" {
 
   security_group_ids  = [aws_security_group.ssm_vpce_sg.id]
   private_dns_enabled = true
-  subnet_ids          = [module.vpc.private_subnets[0]]
+  subnet_ids          = [local.webserver_subnet]
 }
 
 resource "aws_vpc_endpoint" "ssm_message_vpce" {
@@ -17,6 +17,6 @@ resource "aws_vpc_endpoint" "ssm_message_vpce" {
 
   security_group_ids  = [aws_security_group.ssm_vpce_sg.id]
   private_dns_enabled = true
-  subnet_ids          = [module.vpc.private_subnets[0]]
+  subnet_ids          = [local.webserver_subnet]
 }
 

--- a/infra/app/locals.tf
+++ b/infra/app/locals.tf
@@ -6,4 +6,6 @@ locals {
 
   private_subnets = [for index, az in local.vpc_azs : cidrsubnet(local.vpc_cidr, 8, index)]
   public_subnets  = [for index, az in local.vpc_azs : cidrsubnet(local.vpc_cidr, 8, index + local.num_azs)]
+
+  webserver_subnet = module.vpc.public_subnets[0]
 }


### PR DESCRIPTION
## Context
As of the free-tier amazon-linux AMI, docker is not previously installed and even if it was it wouldn't be able to access docker hub without a proper NAT gateway which is quite expensive in terms of AWS service.
Thus, the webserver instance will temporarily be hosted on a public subnet until I implement my own NAT gateway or an image at ECR.